### PR TITLE
:fix: Iniciar noticia no inicio da tela quando selecionada

### DIFF
--- a/src/app/pages/noticia/noticia.component.ts
+++ b/src/app/pages/noticia/noticia.component.ts
@@ -22,16 +22,12 @@ export class NoticiaComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    window.scrollTo(0, 0);
     this.genero = this.activatedRoute.snapshot.paramMap.get('genero');
     this.ImagemFundo = this.activatedRoute.snapshot.paramMap.get('imagem');
     this.titulo = this.activatedRoute.snapshot.paramMap.get('titulo');
     this.data = this.activatedRoute.snapshot.paramMap.get('data');
     this.descricao = this.activatedRoute.snapshot.paramMap.get('descricao');
-    console.log(this.genero)
-    console.log(this.ImagemFundo)
-    console.log(this.titulo)
-    console.log(this.data)
-    console.log(this.descricao)
   }
 
 }


### PR DESCRIPTION
Anteriormente quando a noticia era selecionada a tela permanecia na mesma posição do card que foi selecionado, sendo necessário voltar ao inicio da tela de maneira manual. Este problema foi corrigido adicionando window.scrollTo no OnInit do componente noticia.